### PR TITLE
Fixed bug to get multiple events per room and day.

### DIFF
--- a/get_indico_events_to_ics.py
+++ b/get_indico_events_to_ics.py
@@ -99,10 +99,9 @@ def get_event(booking):
 
 def get_calendar(bookings):
     calendar = Calendar()
-    for booking in bookings:
-        list_of_events = range(len(booking)) #expect more than 1 event per room and day
-        for index in list_of_events:
-            event = get_event(booking[index])
+    for room_bookings in bookings:
+        for room_booking in room_bookings:
+            event = get_event(room_booking)
             calendar.add_component(event)
     return calendar
 

--- a/get_indico_events_to_ics.py
+++ b/get_indico_events_to_ics.py
@@ -100,9 +100,10 @@ def get_event(booking):
 def get_calendar(bookings):
     calendar = Calendar()
     for booking in bookings:
-        booking = booking[0] #This is ugly and we could replace it by looping over map(lambda x: x[0], bookings) but it might be more portable
-        event = get_event(booking)
-        calendar.add_component(event)
+        list_of_events = range(len(booking)) #expect more than 1 event per room and day
+        for index in list_of_events:
+            event = get_event(booking[index])
+            calendar.add_component(event)
     return calendar
 
 def save_calendar_to_file(calendar, room_id):


### PR DESCRIPTION
Downloading room booking information to ics files showed that only the first event per room and date got downloaded and transferred to the cirresponding ics file. This was caused due to a missing loop over all booking of a room at a certain date. The pull request here fixes this issue. Anyway other things might be broken by the fix, so it should be carefully tested.